### PR TITLE
Add fixtures for transport objects

### DIFF
--- a/frontend/src/fixtures/transportFixtures.js
+++ b/frontend/src/fixtures/transportFixtures.js
@@ -1,0 +1,38 @@
+const transportFixtures = {
+    oneTransport:
+    [
+      {
+        "id": 1,
+        "name": "Standard Kart",
+        "mode": "kart",
+        "cost": 100,  
+      }
+    ],
+
+    threeTransports:
+    [
+        {
+            "id": 2,
+            "name": "Biddybuggy",
+            "mode": "kart",
+            "cost": 1000,
+        },
+
+        {
+            "id": 3,
+            "name": "Inkstriker",
+            "mode": "kart",
+            "cost": 10000, 
+        },
+
+        {
+            "id": 4,
+            "name": "Mr. Scooty",
+            "mode": "scooter",
+            "cost": 100000,     
+        },
+        
+    ]
+};
+
+export { transportFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for transport objects to be used in testing and storybook entries.
