### PR TITLE
iw - expand table for books on webpage

### DIFF
--- a/frontend/src/main/components/Books/BookTable.js
+++ b/frontend/src/main/components/Books/BookTable.js
@@ -42,6 +42,14 @@ export default function BookTable({
         {
             Header: 'Author',
             accessor: 'author',
+        },
+        {
+            Header: 'Genre',
+            accessor: 'genre',
+        },
+        {
+            Header: 'Word count',
+            accessor: 'word count',
         }
     ];
 

--- a/frontend/src/tests/components/Books/BookTable.test.js
+++ b/frontend/src/tests/components/Books/BookTable.test.js
@@ -15,8 +15,8 @@ jest.mock('react-router-dom', () => ({
 describe("BookTable tests", () => {
   const queryClient = new QueryClient();
 
-  const expectedHeaders = ["id", "Name", "Author"];
-  const expectedFields = ["id", "name", "author"];
+  const expectedHeaders = ["id", "Name", "Author", "Genre", "Word count"];
+  const expectedFields = ["id", "name", "author", "genre", "word count"];
   const testId = "BookTable";
 
   test("showCell function works properly", () => {
@@ -141,7 +141,7 @@ describe("BookTable tests", () => {
     // assert - check that the console.log was called with the expected message
     expect(console.log).toHaveBeenCalled();
     const message = console.log.mock.calls[0][0];
-    const expectedMessage = `editCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan"})`;
+    const expectedMessage = `editCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan","genre":"Nonfiction","word count":"87223"})`;
     expect(message).toMatch(expectedMessage);
     restoreConsole();
   });
@@ -175,7 +175,7 @@ describe("BookTable tests", () => {
     // assert - check that the console.log was called with the expected message
     expect(console.log).toHaveBeenCalled();
     const message = console.log.mock.calls[0][0];
-    const expectedMessage = `detailsCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan"})`;
+    const expectedMessage = `detailsCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan","genre":"Nonfiction","word count":"87223"})`;
     expect(message).toMatch(expectedMessage);
     restoreConsole();
   });
@@ -206,7 +206,7 @@ describe("BookTable tests", () => {
      // assert - check that the console.log was called with the expected message
      await(waitFor(() => expect(console.log).toHaveBeenCalled()));
      const message = console.log.mock.calls[0][0];
-     const expectedMessage = `deleteCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan"})`;
+     const expectedMessage = `deleteCallback: {"id":2,"name":"Percy Jackson and the Lightning Thief","author":"Rick Riordan","genre":"Nonfiction","word count":"87223"})`;
      expect(message).toMatch(expectedMessage);
      restoreConsole();
   });

--- a/frontend/src/tests/pages/Books/BookIndexPage.test.js
+++ b/frontend/src/tests/pages/Books/BookIndexPage.test.js
@@ -106,7 +106,7 @@ describe("BookIndexPage tests", () => {
         // assert - check that the console.log was called with the expected message
         expect(console.log).toHaveBeenCalled();
         const message = console.log.mock.calls[0][0];
-        const expectedMessage = `BookIndexPage deleteCallback: {"id":3,"name":"Parameterized Algorithms","author":"Daniel Lokshtanov"}`;
+        const expectedMessage = `BookIndexPage deleteCallback: {"id":3,"name":"Parameterized Algorithms","author":"Daniel Lokshtanov","genre":"Fantasy","word count":"too many"}`;
         expect(message).toMatch(expectedMessage);
         restoreConsole();
 


### PR DESCRIPTION
In this PR, I expanded the table on the webpage for books.

Used to: only showed book title and author

Now: in addition to title and author, also shows genre and word count